### PR TITLE
fix: change like function to use request rather than passed param

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -7,9 +7,11 @@ use Illuminate\Http\Request;
 
 class PostsController extends Controller
 {
-    public function like($postID)
+    public function like(Request $request)
     {
-        $post = Post::find($postID);
+        $postID = $request->postID;
+
+        $post = Post::findOrFail($postID);
         $post->likes++;
         $post->save();
 


### PR DESCRIPTION
After consulting with @willyyhuang, the Like function on the PostsController now uses items passed in the request rather than an ID passed in the URL. Also throw a 404 for invalid posts.