### PR TITLE
fix: retrieve post comments on index and post show routes

### DIFF
--- a/app/Http/Controllers/PagesController.php
+++ b/app/Http/Controllers/PagesController.php
@@ -12,10 +12,11 @@ class PagesController extends Controller
     {
         $user = Auth::user();
         $followers = $user->following()->get()->pluck('id');
-        $posts = Post::whereIn('author_id', $followers)->get();
+        $posts = Post::with(['comments', 'author'])->whereIn('author_id', $followers)->get();
         if ($posts->isEmpty()) {
-            $posts = Post::limit(50)->orderBy('likes', 'desc')->get();
+            $posts = Post::with(['comments', 'author'])->limit(50)->orderBy('likes', 'desc')->get();
         }
+        
         return view('index')->with(compact(['posts']));
     }
 }

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -18,7 +18,7 @@ class PostsController extends Controller
         return response(['success'=>true]);
     }
     public function show($postID){
-        $post = Post::findorFail($postID);
+        $post = Post::with('comments', 'author')->findorFail($postID);
 
         return View("posts.view")->with(compact(["post"]));
     }


### PR DESCRIPTION
solves #50, posts are now accompanied by their author and comments relations. They are accessed by calling `$post->author` and `$post->comments`, respectively. 